### PR TITLE
Add non-profit subtitle to all main pages

### DIFF
--- a/aerotow.htm
+++ b/aerotow.htm
@@ -48,6 +48,9 @@
     <section class="section">
         <div class="container">
             <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+            <p class="subtitle has-text-centered large-text">
+                A non-profit organization for the preservation of recreational hang gliding
+            </p>
             <div class="columns is-vcentered">
                 <div class="column is-2">
                     <a href="#"><img src="soga mountain logo.jpg" alt="SOGA Mountain Logo" class="soga-logo"></a>

--- a/contact2.htm
+++ b/contact2.htm
@@ -17,6 +17,9 @@
 <section class="section">
     <div class="container">
         <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+        <p class="subtitle has-text-centered large-text">
+            A non-profit organization for the preservation of recreational hang gliding
+        </p>
 
         <!-- Logo and Navigation Bar -->
         <div class="columns is-vcentered">

--- a/events.htm
+++ b/events.htm
@@ -42,6 +42,9 @@
 <body class="has-background-light">
     <div class="container">
         <h2 class="title has-text-centered">Southwestern Ontario Gliding Association</h2>
+        <p class="subtitle has-text-centered large-text">
+            A non-profit organization for the preservation of recreational hang gliding
+        </p>
         <!-- Logo and Navigation Bar -->
         <div class="columns is-vcentered">
             <!-- Logo -->

--- a/gallery.htm
+++ b/gallery.htm
@@ -29,6 +29,9 @@
             <h2 class="title has-text-centered">
                 SOUTHWESTERN ONTARIO GLIDING ASSOCIATION
             </h2>
+            <p class="subtitle has-text-centered large-text">
+                A non-profit organization for the preservation of recreational hang gliding
+            </p>
 
             <!-- Logo and Navigation Bar -->
             <div class="columns is-vcentered">

--- a/membership.htm
+++ b/membership.htm
@@ -16,6 +16,9 @@
 <section class="section">
     <div class="container">
         <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+        <p class="subtitle has-text-centered large-text">
+            A non-profit organization for the preservation of recreational hang gliding
+        </p>
 
         <!-- Logo and Navigation Bar -->
         <div class="columns is-vcentered">


### PR DESCRIPTION
## Summary
Add the non-profit subtitle "A non-profit organization for the preservation of recreational hang gliding" to all main navigation pages for consistent branding across the entire site.

## Changes Made
- **aerotow.htm**: Added subtitle below main title
- **contact2.htm**: Added subtitle below main title  
- **events.htm**: Added subtitle below main title
- **gallery.htm**: Added subtitle below main title
- **membership.htm**: Added subtitle below main title

## Styling
- Uses same `subtitle has-text-centered large-text` classes as homepage
- Maintains consistent visual hierarchy across all pages
- Positioned between main title and navigation bar

## Test Plan
- [x] Verify subtitle appears correctly on all pages
- [x] Verify styling consistency with homepage
- [x] Check responsive design compatibility
- [x] Ensure no layout disruption

🤖 Generated with [Claude Code](https://claude.ai/code)