### PR TITLE
Add missing subtitle to blogs page

### DIFF
--- a/blogs.htm
+++ b/blogs.htm
@@ -20,6 +20,9 @@
             <h2 class="title has-text-centered">
                 SOUTHWESTERN ONTARIO GLIDING ASSOCIATION
             </h2>
+            <p class="subtitle has-text-centered large-text">
+                A non-profit organization for the preservation of recreational hang gliding
+            </p>
 
             <!-- Logo and Navigation Bar -->
             <div class="columns is-vcentered">


### PR DESCRIPTION
## Summary
Add the non-profit subtitle to the blogs page to complete consistent branding across all main navigation pages.

## Changes Made
- **blogs.htm**: Added subtitle "A non-profit organization for the preservation of recreational hang gliding"

## Styling
- Uses same `subtitle has-text-centered large-text` classes as other pages
- Positioned between main title and navigation bar
- Maintains visual consistency with homepage and other pages

## Test Plan
- [x] Verify subtitle appears correctly on blogs page
- [x] Verify styling consistency with other pages
- [x] Ensure memorial button positioning remains correct

🤖 Generated with [Claude Code](https://claude.ai/code)