### PR TITLE
Redesign header: Enlarge logo and left-align elements

### DIFF
--- a/aerotow.htm
+++ b/aerotow.htm
@@ -16,19 +16,18 @@
 <body class="has-background-light">
     <section class="section">
         <div class="container">
-            <div class="columns is-vcentered">
+            <div class="columns is-vcentered header-columns">
                 <div class="column is-narrow">
                     <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
                 </div>
                 <div class="column">
-                    <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
-                    <p class="subtitle has-text-centered large-text">
+                    <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+                    <p class="subtitle has-text-left large-text">
                 A non-profit organization for the preservation of recreational hang gliding
             </p>
-                </div>
-            </div>
+                
             <!-- Navigation Bar -->
-            <div class="tabs is-centered">
+            <div class="tabs is-left">
                                     <ul>
                                         <li class="navbar-item"><a href="soga.htm">SOGA</a></li>
                                         <li class="navbar-item"><a href="membership.htm">MEMBERSHIP</a></li>
@@ -38,6 +37,8 @@
                                         <li class="navbar-item"><a href="contact2.htm">CONTACT</a></li>
                                     </ul>
                                 </div>
+            </div>
+            </div>
 
             <img src="soga13banner1.jpg" alt="SOGA Banner" class="mt-4 mb-4">
             <div class="content has-text-centered large-text narrow-paragraph">

--- a/aerotow.htm
+++ b/aerotow.htm
@@ -18,7 +18,7 @@
         <div class="container">
             <div class="columns is-vcentered header-columns">
                 <div class="column is-narrow">
-                    <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
+                    <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo-large"></a>
                 </div>
                 <div class="column">
                     <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>

--- a/contact2.htm
+++ b/contact2.htm
@@ -16,20 +16,19 @@
 <body class="has-background-light">
 <section class="section">
     <div class="container">
-        <div class="columns is-vcentered">
+        <div class="columns is-vcentered header-columns">
             <div class="column is-narrow">
                 <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
             </div>
             <div class="column">
-                <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
-                <p class="subtitle has-text-centered large-text">
+                <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+                <p class="subtitle has-text-left large-text">
             A non-profit organization for the preservation of recreational hang gliding
         </p>
-            </div>
-        </div>
+            
 
         <!-- Navigation Bar -->
-        <div class="tabs is-centered">
+        <div class="tabs is-left">
                             <ul>
                                 <li class="navbar-item"><a href="soga.htm">SOGA</a></li>
                                 <li class="navbar-item"><a href="membership.htm">MEMBERSHIP</a></li>
@@ -39,6 +38,8 @@
                                 <li class="navbar-item is-active"><a href="contact2.htm">CONTACT</a></li>
                             </ul>
                         </div>
+            </div>
+        </div>
 
         <!-- Main Content -->
         <div class="content has-text-centered main-content large-text">

--- a/contact2.htm
+++ b/contact2.htm
@@ -18,7 +18,7 @@
     <div class="container">
         <div class="columns is-vcentered header-columns">
             <div class="column is-narrow">
-                <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
+                <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo-large"></a>
             </div>
             <div class="column">
                 <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>

--- a/events.htm
+++ b/events.htm
@@ -18,7 +18,7 @@
     <div class="container">
         <div class="columns is-vcentered header-columns">
             <div class="column is-narrow">
-                <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
+                <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo-large"></a>
             </div>
             <div class="column">
                 <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>

--- a/events.htm
+++ b/events.htm
@@ -16,19 +16,18 @@
 <body class="has-background-light">
     <section class="section">
     <div class="container">
-        <div class="columns is-vcentered">
+        <div class="columns is-vcentered header-columns">
             <div class="column is-narrow">
                 <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
             </div>
             <div class="column">
-                <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
-                <p class="subtitle has-text-centered large-text">
+                <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+                <p class="subtitle has-text-left large-text">
             A non-profit organization for the preservation of recreational hang gliding
         </p>
-            </div>
-        </div>
+            
         <!-- Navigation Bar -->
-        <div class="tabs is-centered">
+        <div class="tabs is-left">
                             <ul>
                                 <li class="navbar-item"><a href="soga.htm">SOGA</a></li>
                                 <li class="navbar-item"><a href="membership.htm">MEMBERSHIP</a></li>
@@ -38,6 +37,8 @@
                                 <li class="navbar-item"><a href="contact2.htm">CONTACT</a></li>
                             </ul>
                         </div>
+            </div>
+        </div>
         <main>
             <img src="setup2a.jpg" alt="Event Setup" class="mt-4 mb-4">
             <div class="content has-text-centered large-text narrow-paragraph">

--- a/gallery.htm
+++ b/gallery.htm
@@ -16,20 +16,19 @@
 <body class="has-background-light">
     <section class="section">
         <div class="container">
-            <div class="columns is-vcentered">
+            <div class="columns is-vcentered header-columns">
                 <div class="column is-narrow">
                     <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
                 </div>
                 <div class="column">
-                    <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
-                    <p class="subtitle has-text-centered large-text">
+                    <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+                    <p class="subtitle has-text-left large-text">
                 A non-profit organization for the preservation of recreational hang gliding
             </p>
-                </div>
-            </div>
+                
 
             <!-- Navigation Bar -->
-            <div class="tabs is-centered">
+            <div class="tabs is-left">
                                     <ul>
                                         <li class="navbar-item"><a href="soga.htm">SOGA</a></li>
                                         <li class="navbar-item"><a href="membership.htm">MEMBERSHIP</a></li>
@@ -39,6 +38,8 @@
                                         <li class="navbar-item"><a href="contact2.htm">CONTACT</a></li>
                                     </ul>
                                 </div>
+            </div>
+            </div>
 
             <!-- Memorial Button for Bob Grant -->
             <div class="has-text-centered" style="margin: 2rem 0; clear: both; position: relative; z-index: 20;">

--- a/gallery.htm
+++ b/gallery.htm
@@ -18,7 +18,7 @@
         <div class="container">
             <div class="columns is-vcentered header-columns">
                 <div class="column is-narrow">
-                    <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
+                    <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo-large"></a>
                 </div>
                 <div class="column">
                     <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>

--- a/membership.htm
+++ b/membership.htm
@@ -15,20 +15,19 @@
 
 <section class="section">
     <div class="container">
-        <div class="columns is-vcentered">
+        <div class="columns is-vcentered header-columns">
             <div class="column is-narrow">
                 <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
             </div>
             <div class="column">
-                <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
-                <p class="subtitle has-text-centered large-text">
+                <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+                <p class="subtitle has-text-left large-text">
             A non-profit organization for the preservation of recreational hang gliding
         </p>
-            </div>
-        </div>
+            
 
         <!-- Navigation Bar -->
-        <div class="tabs is-centered">
+        <div class="tabs is-left">
                             <ul>
                                 <li class="navbar-item"><a href="soga.htm">SOGA</a></li>
                                 <li class="navbar-item is-active"><a href="membership.htm">MEMBERSHIP</a></li>
@@ -38,6 +37,8 @@
                                 <li class="navbar-item"><a href="contact2.htm">CONTACT</a></li>
                             </ul>
                         </div>
+            </div>
+        </div>
 
         <img src="SOGA Comp 2010.jpg" class="header-image" alt="SOGA Image">
 

--- a/membership.htm
+++ b/membership.htm
@@ -17,7 +17,7 @@
     <div class="container">
         <div class="columns is-vcentered header-columns">
             <div class="column is-narrow">
-                <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
+                <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo-large"></a>
             </div>
             <div class="column">
                 <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>

--- a/soga.htm
+++ b/soga.htm
@@ -15,20 +15,19 @@
 
 <section class="section">
     <div class="container">
-        <div class="columns is-vcentered">
+        <div class="columns is-vcentered header-columns">
             <div class="column is-narrow">
                 <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
             </div>
             <div class="column">
-                <h2 class="title has-text-centered">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
-                <p class="subtitle has-text-centered large-text">
+                <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>
+                <p class="subtitle has-text-left large-text">
             A non-profit organization for the preservation of recreational hang gliding
         </p>
-            </div>
-        </div>
+            
 
         <!-- Navigation Bar -->
-        <div class="tabs is-centered">
+        <div class="tabs is-left">
                             <ul>
                                 <li class="navbar-item is-active"><a href="soga.htm">SOGA</a></li>
                                 <li class="navbar-item"><a href="membership.htm">MEMBERSHIP</a></li>
@@ -38,6 +37,8 @@
                                 <li class="navbar-item"><a href="contact2.htm">CONTACT</a></li>
                             </ul>
                         </div>
+            </div>
+        </div>
 
         <img src="Getting Ready 2a.jpg" alt="Getting Ready" class="mt-4 mb-4">
 

--- a/soga.htm
+++ b/soga.htm
@@ -17,7 +17,7 @@
     <div class="container">
         <div class="columns is-vcentered header-columns">
             <div class="column is-narrow">
-                <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo"></a>
+                <a href="soga.htm"><img src="soga-shield.png" alt="SOGA Logo" class="soga-logo-large"></a>
             </div>
             <div class="column">
                 <h2 class="title has-text-left">SOUTHWESTERN ONTARIO GLIDING ASSOCIATION</h2>

--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,14 @@
     font-size: 1.5em;
 }
 .soga-logo {
-    width: 250px;      /* enlarged shield badge */
+    width: 150px;      /* original shield badge size */
+    max-width: 40%;    /* shrink gracefully on narrow screens */
+    height: auto;
+    display: block;
+    margin: 0;         /* anchored left */
+}
+.soga-logo-large {
+    width: 250px;      /* enlarged shield badge for main pages */
     height: auto;
     display: block;
     margin: 0;         /* anchored left */

--- a/styles.css
+++ b/styles.css
@@ -2,11 +2,13 @@
     font-size: 1.5em;
 }
 .soga-logo {
-    width: 150px;      /* shield badge, top-left of each page */
-    max-width: 40%;    /* shrink gracefully on narrow screens */
+    width: 250px;      /* enlarged shield badge */
     height: auto;
     display: block;
     margin: 0;         /* anchored left */
+}
+.header-columns {
+    gap: 0.5rem;       /* pull titles closer to logo */
 }
 .navbar-item {
     font-size: 1.3em;


### PR DESCRIPTION
This PR enlarges the SOGA logo to 250px and restructures the header to left-align the titles and navigation bar, ensuring they are positioned close to the logo as requested.